### PR TITLE
[Fix] Use CordovaPreferences on Android.

### DIFF
--- a/src/android/AppSettings.java
+++ b/src/android/AppSettings.java
@@ -4,6 +4,7 @@ import java.util.Locale;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaPreferences;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -17,9 +18,10 @@ public class AppSettings extends CordovaPlugin {
     	JSONObject options = new JSONObject();
         if (action.equals("get")) {
         	try{
+                CordovaPreferences preferences = webView.getPreferences();
                 for(int i=0;i<args.length();i++){
         	        String key=args.getString(i);
-                    String keyvalue = cordova.getActivity().getIntent().getStringExtra(key.toLowerCase(Locale.getDefault()));        		
+                    String keyvalue = preferences.getString(key, null);
                     if (keyvalue != null) {
                         options.put(key, keyvalue);
                     }


### PR DESCRIPTION
Since Cordova Android 4.x, preferences are no longer written in the intent extras and the preferred way is to use `CordovaPreferences`.
See here: https://github.com/apache/cordova-android/commit/a64203f8174b42d6359f0bbdc7b69d96497b203a

`CordovaPreferences` is available starting Cordova Android 3.6.x.
