### PR TITLE
Reorderd the arguments in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ https://www.npmjs.com/package/cordova-plugin-appsettings
     cordova plugin add cordova-plugin-appsettings
 
     AppSettings.get(
+        ["Preference1", "Preference2"],
     	function(value) {
     		alert("Value: " + JSON.stringify(value));
     	},
     	function(error) {
         	alert("Error! " + JSON.stringify(error));
-    }, ["Preference1", "Preference2"]);
+    });
 
 ## Credits
 https://github.com/apache/cordova-labs/tree/cdvtest


### PR DESCRIPTION
The order of arguments in AppSettings.get is now
AppSettings.get( Array: Values, Function: Callback Success [, Function: Callback Failure])
