### PR TITLE
Similarity with iOS results

### DIFF
--- a/src/android/AppSettings.java
+++ b/src/android/AppSettings.java
@@ -1,6 +1,7 @@
 package org.apache.cordova.appsettings;
 
 import java.util.Locale;
+import java.lang.String;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -23,7 +24,7 @@ public class AppSettings extends CordovaPlugin {
         	        String key=args.getString(i);
                     String keyvalue = preferences.getString(key, null);
                     if (keyvalue != null) {
-                        options.put(key, keyvalue);
+                        options.put(key.toLowerCase(), keyvalue);
                     }
                 }
                 callbackContext.success(options);


### PR DESCRIPTION
The result keys in the iOS version are returned in lowerCase.

In case of a "<preference name='prefName' value='..'>" 
it was needed to get:
* "values.prefName" in android 
* "values.prefname" in iOS.
Now both: "values.prefname"